### PR TITLE
Some changes are needed to device tree of A5 in order to make it buildable again

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -87,7 +87,7 @@ OVERRIDE_RS_DRIVER := libRSDriver_adreno.so
 
 # Includes
 TARGET_SPECIFIC_HEADER_PATH := device/htc/a5/include
-m
+
 # Libc extensions
 BOARD_PROVIDES_ADDITIONAL_BIONIC_STATIC_LIBS += libc_htc_symbols
 

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -87,12 +87,15 @@ OVERRIDE_RS_DRIVER := libRSDriver_adreno.so
 
 # Includes
 TARGET_SPECIFIC_HEADER_PATH := device/htc/a5/include
+m
+# Libc extensions
+BOARD_PROVIDES_ADDITIONAL_BIONIC_STATIC_LIBS += libc_htc_symbols
 
 # Lights
 TARGET_PROVIDES_LIBLIGHT := true
 
 # Logging
-COMMON_GLOBAL_CFLAGS += -DHTCLOG -DMOTOROLA_LOG
+COMMON_GLOBAL_CFLAGS += -DHTCLOG 
 
 # NFC
 BOARD_NFC_CHIPSET := pn547

--- a/libc_htc_symbols/Android.mk
+++ b/libc_htc_symbols/Android.mk
@@ -1,0 +1,25 @@
+# Copyright (C) 2015 The CyanogenMod Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := \
+    htc_log.c
+
+LOCAL_MODULE_PATH := $(TARGET_OUT_SHARED_LIBRARIES)
+LOCAL_MODULE := libc_htc_symbols
+LOCAL_MODULE_TAGS := optional
+
+include $(BUILD_STATIC_LIBRARY)

--- a/libc_htc_symbols/htc_log.c
+++ b/libc_htc_symbols/htc_log.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __unused
+#define __unused  __attribute__((__unused__))
+#endif
+
+signed int __htclog_read_masks(char *buf __unused, signed int len __unused)
+{
+    return 0;
+}
+
+int __htclog_init_mask(const char *a1 __unused, unsigned int a2 __unused, int a3 __unused)
+{
+    return 0;
+}
+
+int __htclog_print_private(int a1 __unused, const char *a2 __unused, const char *fmt __unused, ...)
+{
+    return 0;
+}

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -203,9 +203,6 @@ on post-fs-data
     #Create a folder for SRS to be able to create a usercfg file
     mkdir /data/data/media 0770 media media
 
-    # Hardware tunables
-    chown system system /sys/devices/virtual/graphics/fb0/rgb
-    chmod 0660 /sys/devices/virtual/graphics/fb0/rgb
 
 on early-boot
     # set RLIMIT_MEMLOCK to 64MB

--- a/sepolicy/file.te
+++ b/sepolicy/file.te
@@ -1,2 +1,1 @@
-type display_sysfs, sysfs_type, file_type;
 type vibe_dev, file_type;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -25,5 +25,4 @@
 
 /data/system/default_values	u:object_r:mpctl_data_file:s0
 
-/sys/devices/virtual/graphics/fb0/rgb			u:object_r:display_sysfs:s0
 /sys/devices/virtual/timed_output/vibrator/pwm_value_1p u:object_r:vibe_dev:s0

--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -1,3 +1,1 @@
-allow system_server time_daemon:unix_stream_socket connectto;
-allow system_server display_sysfs:file rw_file_perms;
 allow system_server vibe_dev:file rw_file_perms;


### PR DESCRIPTION
Some changes are needed to device tree of A5 in order to make it buildable and bootable again. I have done the changes in my local copy and it is building and booting up again. Please give a look to url below.

http://review.cyanogenmod.org/#/c/109565/ - __htclog_init_mask() needed by libtime.so
http://review.cyanogenmod.org/#/c/109691/ - Relocating livedisplay sepolicy to vendor_cm